### PR TITLE
Add support for MediatR v14.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,17 +5,18 @@
   </PropertyGroup>
   
   <ItemGroup Label="Package dependencies">
-    <PackageVersion Include="MediatR" Version="12.4.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="MediatR" Version="14.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
   </ItemGroup>
   
   <ItemGroup Label="Test projects dependencies">
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.1" />
+    <PackageVersion Include="FluentAssertions" Version="[7.2.0]" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
   
   <ItemGroup Label="Transitive Updates">

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>MediatR</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -38,9 +38,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../pozitronicon.png" Pack="true" PackagePath="\" />
-    <None Include="../../readme-nuget.md" Pack="true" PackagePath="\" />
-    <None Include="../../LICENSE.txt" Pack="true" PackagePath="\" />
+    <None Include="../../pozitronicon.png" Pack="true" PackagePath="" Visible="false" />
+    <None Include="../../readme-nuget.md" Pack="true" PackagePath="" Visible="false" />
+    <None Include="../../LICENSE.txt" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/Pozitron.Extensions.MediatR.Tests/ExtendedMediatorTests.cs
+++ b/tests/Pozitron.Extensions.MediatR.Tests/ExtendedMediatorTests.cs
@@ -9,6 +9,7 @@ public class ExtendedMediatorTests
     public async Task PublishExtension_ThrowsNotSupported_GivenExtendedMediatorNotRegistered()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddMediatR(x =>
         {
             x.RegisterServicesFromAssemblyContaining<Ping>();
@@ -24,6 +25,7 @@ public class ExtendedMediatorTests
     public async Task Publish_FallsBackToDefault_GivenInvalidStrategy()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(typeof(Ping));
         using var scope = services.BuildServiceProvider().CreateScope();

--- a/tests/Pozitron.Extensions.MediatR.Tests/Pozitron.Extensions.MediatR.Tests.csproj
+++ b/tests/Pozitron.Extensions.MediatR.Tests/Pozitron.Extensions.MediatR.Tests.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/tests/Pozitron.Extensions.MediatR.Tests/Publishers/SequentialAllTests.cs
+++ b/tests/Pozitron.Extensions.MediatR.Tests/Publishers/SequentialAllTests.cs
@@ -8,6 +8,7 @@ public class SequentialAllTests
     public async Task ExecutesAllHandlersSequentially()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -28,6 +29,7 @@ public class SequentialAllTests
     public async Task ContinuesOnException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(typeof(Ping));
         using var scope = services.BuildServiceProvider().CreateScope();
@@ -46,6 +48,7 @@ public class SequentialAllTests
     public async Task FlattensAggregateException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {

--- a/tests/Pozitron.Extensions.MediatR.Tests/Publishers/SequentialTests.cs
+++ b/tests/Pozitron.Extensions.MediatR.Tests/Publishers/SequentialTests.cs
@@ -8,6 +8,7 @@ public class SequentialTests
     public async Task ExecutesAllHandlersSequentially()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -28,6 +29,7 @@ public class SequentialTests
     public async Task StopsOnException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(typeof(Ping));
         using var scope = services.BuildServiceProvider().CreateScope();

--- a/tests/Pozitron.Extensions.MediatR.Tests/Publishers/WhenAllBackgroundTests.cs
+++ b/tests/Pozitron.Extensions.MediatR.Tests/Publishers/WhenAllBackgroundTests.cs
@@ -8,6 +8,7 @@ public class WhenAllBackgroundTests
     public async Task ExecutesAllHandlersConcurrently()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -28,6 +29,7 @@ public class WhenAllBackgroundTests
     {
         var logger = new FakeLogger<ExtendedMediator>(_queue);
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddSingleton(typeof(ILogger<ExtendedMediator>), _ => logger);
         services.AddExtendedMediatR(typeof(Ping));

--- a/tests/Pozitron.Extensions.MediatR.Tests/Publishers/WhenAllTests.cs
+++ b/tests/Pozitron.Extensions.MediatR.Tests/Publishers/WhenAllTests.cs
@@ -8,6 +8,7 @@ public class WhenAllTests
     public async Task ExecutesAllHandlersConcurrently()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -29,6 +30,7 @@ public class WhenAllTests
     public async Task FlattensAllExceptions()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(typeof(Ping));
         using var scope = services.BuildServiceProvider().CreateScope();
@@ -48,6 +50,7 @@ public class WhenAllTests
     public async Task ImmediateSingleException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -67,6 +70,7 @@ public class WhenAllTests
     public async Task ImmediateAggregateException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -86,6 +90,7 @@ public class WhenAllTests
     public async Task SingleException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -105,6 +110,7 @@ public class WhenAllTests
     public async Task SingleAggregateException()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {
@@ -124,6 +130,7 @@ public class WhenAllTests
     public async Task TaskCanceledExceptions()
     {
         var services = new ServiceCollection();
+        services.AddLogging();
         services.AddSingleton(_queue);
         services.AddExtendedMediatR(x =>
         {


### PR DESCRIPTION
- Depend on new version of MediatR, v14.0.0
- Align TFM support with MediatR, `netstandard2.0`, `net8.0`, `net9.0`, `net10.0`